### PR TITLE
既にあるアイテムに向かって釣竿を投げた場合に誤検知される問題の修正

### DIFF
--- a/scripts/events/playerFishingAfterEvent.js
+++ b/scripts/events/playerFishingAfterEvent.js
@@ -59,6 +59,15 @@ world.beforeEvents.itemUse.subscribe(ev => {
 
 world.afterEvents.entitySpawn.subscribe(ev => {
     const { entity } = ev;
+    
+    //スポーンしたアイテムに時間のプロパティを追加
+    if (entity.typeId === "minecraft:item") {
+        entity.time = Date.now();
+    };
+});
+
+world.afterEvents.entitySpawn.subscribe(ev => {
+    const { entity } = ev;
 
     if (entity.typeId === "minecraft:fishing_hook") {
         const player = fishingPlayerQueue[0];
@@ -82,6 +91,9 @@ world.beforeEvents.entityRemove.subscribe(ev => {
             minDistance: 0,
             maxDistance: 0.2
         })[0];
+
+        //既にあるアイテムに釣竿が当たってた場合、終了
+        if (item?.time) return;
 
         /** @type {PlayerFishingAfterEvent} */
         let events = {};


### PR DESCRIPTION
今まで既にあるアイテムに釣竿を投げてそのあとまた釣竿を振ると誤検知されていたため、修正しました